### PR TITLE
Assets as option

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -181,7 +181,7 @@ function resolveAsset(eyeglass, sass, sassUtils, registeredAssetsMap, relativePa
     var filepath = data.coerce.get("filepath");
     var fullUri = httpJoin(
                     eyeglass.options.eyeglass.httpRoot,
-                    eyeglass.options.eyeglass.assetsHttpPrefix,
+                    eyeglass.options.eyeglass.assets.httpPrefix,
                     uri);
 
     eyeglass.assets.resolve(filepath, fullUri, function(error, assetUriInfo) {
@@ -190,8 +190,8 @@ function resolveAsset(eyeglass, sass, sassUtils, registeredAssetsMap, relativePa
       } else {
         // handle a string here?
         var finalUri = assetUriInfo.path;
-        if (eyeglass.options.eyeglass.assetsRelativeTo) {
-          finalUri = path.relative(eyeglass.options.eyeglass.assetsRelativeTo, assetUriInfo.path);
+        if (eyeglass.options.eyeglass.assets.relativeTo) {
+          finalUri = path.relative(eyeglass.options.eyeglass.assets.relativeTo, assetUriInfo.path);
         }
         // if a query param was specified, append it to the uri query
         if (assetUriInfo.query) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,9 +37,10 @@ function Eyeglass(options, deprecatedNodeSassArg) {
   deprecateProperties.call(this, ["enableImportOnce"]);
 
   // auto-add asset paths specified via options
-  if (this.options.eyeglass.assets) {
-    this.options.eyeglass.assets.forEach(function(assetSource) {
-      this.assets.addSource.apply(this.assets, assetSource);
+  if (this.options.eyeglass.assets.sources) {
+    this.options.eyeglass.assets.sources.forEach(function(assetSource) {
+
+      this.assets.addSource(assetSource.directory, assetSource);
     }.bind(this));
   }
 }

--- a/lib/options.js
+++ b/lib/options.js
@@ -52,8 +52,6 @@ function migrateEyeglassOptionsFromSassOptions(sassOptions, eyeglassOptions, dep
     "cacheDir",
     "buildDir",
     "httpRoot",
-    "assetsHttpPrefix",
-    "assetsRelativeTo",
     "strictModuleVersions"
   ].forEach(function(option) {
     if (eyeglassOptions[option] === undefined && sassOptions[option] !== undefined) {
@@ -63,13 +61,48 @@ function migrateEyeglassOptionsFromSassOptions(sassOptions, eyeglassOptions, dep
         "  /* sassOptions */",
         "  ...",
         "  eyeglass: {",
-        "    option: ...",
+        "    " + option + ": ...",
         "  }",
         "});"
       ].join("\n  "));
 
       eyeglassOptions[option] = sassOptions[option];
       delete sassOptions[option];
+    }
+  });
+}
+
+function migrateAssetOptionsFromSassOptions(sassOptions, eyeglassOptions, deprecate) {
+  // migrates the following properties from sassOptions to eyeglassOptions
+  [
+    ["assetsHttpPrefix", "httpPrefix"],
+    ["assetsRelativeTo", "relativeTo"]
+  ].forEach(function(optionPair) {
+    var fromOption = optionPair[0];
+    var toOption = optionPair[1];
+    if ((eyeglassOptions.assets === undefined ||
+          (eyeglassOptions.assets && eyeglassOptions.assets[toOption] === undefined)) &&
+        sassOptions[fromOption] !== undefined) {
+      deprecate("0.8.0", "0.9.0", [
+        "`" + fromOption +
+          "` has been renamed to `" + toOption +
+          "` and should be passed into the eyeglass asset options rather than the sass options:",
+        "var options = eyeglass({",
+        "  /* sassOptions */",
+        "  ...",
+        "  eyeglass: {",
+        "    assets: {",
+        "      " + toOption + ": ...",
+        "    }",
+        "  }",
+        "});"
+      ].join("\n  "));
+
+      if (eyeglassOptions.assets === undefined) {
+        eyeglassOptions.assets = {};
+      }
+      eyeglassOptions.assets[toOption] = sassOptions[fromOption];
+      delete sassOptions[fromOption];
     }
   });
 }
@@ -88,7 +121,7 @@ function defaultEyeglassOptions(options) {
   options.engines = defaultValue(options.engines, {});
   options.engines.sass = defaultValue(options.engines.sass, require("node-sass"));
   // default assets
-  options.assets = defaultValue(options.assets, []);
+  options.assets = defaultValue(options.assets, {});
   // default httpRoot
   options.httpRoot = defaultValue(options.httpRoot, "/");
   // default enableImportOnce
@@ -128,6 +161,7 @@ function getSassOptions(options, deprecate, sassArg) {
 
   // migrate eyeglassOptions off of the sassOptions (will be deprecated)
   migrateEyeglassOptionsFromSassOptions(sassOptions, eyeglassOptions, deprecate);
+  migrateAssetOptionsFromSassOptions(sassOptions, eyeglassOptions, deprecate);
 
   defaultSassOptions(sassOptions);
   defaultEyeglassOptions(eyeglassOptions);

--- a/site-src/docs/getting_started/index.md
+++ b/site-src/docs/getting_started/index.md
@@ -38,8 +38,8 @@ If there isn't a plugin listed above, you can still use eyeglass! It just takes 
 # Using eyeglass directly with node-sass
 If you are using a build system such as grunt or gulp, you can use the `node-sass` plugin as-is: [grunt-sass](https://github.com/sindresorhus/grunt-sass) and [gulp-sass](https://www.npmjs.com/package/gulp-sass) respectively. In all systems where you can use a `node-sass` build plugin, the recipe is the same:
 
-1. `var Eyeglass = require("eyeglass").Eyeglass;`
-2. `var eyeglass = new Eyeglass({ /* sass options */ });`
-3. Pass in `eyeglass.sassOptions()` wherever the plugin asked for the original sassOptions
+1. `var eyeglass = require("eyeglass");`
+2. Add eyeglass specific options to your node-sass options' `eyeglass` key.
+3. Pass in `eyeglass(sassOptions)` wherever the plugin asked for the original `sassOptions`.
 
 This works because eyeglass is a tool designed to wrap around the `node-sass` options and add a layer of customization based on npm. You can read about the design decisions in [Why eyeglass](../why_eyeglass.md).

--- a/site-src/docs/integrations/gulp.md
+++ b/site-src/docs/integrations/gulp.md
@@ -9,18 +9,17 @@ Additionally, to avoid any problems with `node-sass`, you should provide a defau
 ```js
 var gulp = require("gulp");
 var sass = require("gulp-sass");
-var Eyeglass = require("eyeglass").Eyeglass;
-var sassOptions = {}; // put whatever eyeglass and node-sass options you need here.
-
-var eyeglass = new Eyeglass(sassOptions);
-
-// Disable import once with gulp until we
-// figure out how to make them work together.
-eyeglass.enableImportOnce = false
+var eyeglass = require("eyeglass");
+var sassOptions = {
+  // put node-sass options you need here.
+  eyeglass: {
+    // put eyeglass options you need here.
+  }
+}; 
 
 gulp.task("sass", function () {
   gulp.src("./sass/**/*.scss")
-    .pipe(sass(eyeglass.sassOptions()).on("error", sass.logError))
+    .pipe(sass(eyeglass(sassOptions)).on("error", sass.logError))
     .pipe(gulp.dest("./css"));
 });
 ```

--- a/test/test_assets.js
+++ b/test/test_assets.js
@@ -495,10 +495,12 @@ describe("assets", function () {
       data: input,
       eyeglass: {
         root: rootDir,
-        assets: [
-          [rootDir, {pattern: "images/**/*"}],
-          [rootDir, {pattern: "fonts/**/*"}]
-        ]
+        assets: {
+          sources: [
+            {directory: rootDir, pattern: "images/**/*"},
+            {directory: rootDir, pattern: "fonts/**/*"}
+          ]
+        }
       }
     });
 

--- a/test/test_options.js
+++ b/test/test_options.js
@@ -91,6 +91,8 @@ describe("options", function() {
       var rootDir = testutils.fixtureDirectory("basic_modules");
       var options = {
         root: rootDir,
+        assetsHttpPrefix: "foo",
+        assetsRelativeTo: "/styles/main.css",
         eyeglass: {
           ignoreDeprecations: "0.7.1"
         }
@@ -104,7 +106,27 @@ describe("options", function() {
         "    /* sassOptions */",
         "    ...",
         "    eyeglass: {",
-        "      option: ...",
+        "      root: ...",
+        "    }",
+        "  });",
+        "[eyeglass:deprecation] (deprecated in 0.8.0, will be removed in 0.9.0) `assetsHttpPrefix` has been renamed to `httpPrefix` and should be passed into the eyeglass asset options rather than the sass options:",
+        "  var options = eyeglass({",
+        "    /* sassOptions */",
+        "    ...",
+        "    eyeglass: {",
+        "      assets: {",
+        "        httpPrefix: ...",
+        "      }",
+        "    }",
+        "  });",
+        "[eyeglass:deprecation] (deprecated in 0.8.0, will be removed in 0.9.0) `assetsRelativeTo` has been renamed to `relativeTo` and should be passed into the eyeglass asset options rather than the sass options:",
+        "  var options = eyeglass({",
+        "    /* sassOptions */",
+        "    ...",
+        "    eyeglass: {",
+        "      assets: {",
+        "        relativeTo: ...",
+        "      }",
         "    }",
         "  });",
         "[eyeglass:deprecation] (deprecated in 0.8.0, will be removed in 0.9.0) `require('eyeglass').Eyeglass` is deprecated. " +


### PR DESCRIPTION
Instead of `assets` option being a simple array, it is not it's own options object. the asset sources are passed as the sources key of the assets option. I changed the sources list from an array that was exactly the arguments passed to `addSource` to being an object where the directory is it's own key as I think that reads better in the options context. I then moved the assetsXXX options to assets sub options group and changed their deprecation notices somewhat.

Lastly, I updated all the docs to match this refactor and to remove mentions of deprecated APIs. 
